### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## 概要
 このMCPサーバーは、UUIDを生成するためのシンプルなサービスを提供します。
 
+<a href="https://glama.ai/mcp/servers/@aki-kii/mcp-uuid">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aki-kii/mcp-uuid/badge" alt="UUID Server MCP server" />
+</a>
+
 ## 環境要件
 - Python 3.10以上
 - MCP(Model Context Protocol)パッケージ v1.2.0以上


### PR DESCRIPTION
This PR adds a badge for the [MCP UUID Server](https://glama.ai/mcp/servers/@aki-kii/mcp-uuid) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aki-kii/mcp-uuid">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aki-kii/mcp-uuid/badge" alt="UUID Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.